### PR TITLE
Create pydantic_model_TLV_record_ 7629169.py

### DIFF
--- a/pydantic_model_TLV_record_ 7629169.py
+++ b/pydantic_model_TLV_record_ 7629169.py
@@ -1,0 +1,37 @@
+class KeysendCustomRecord(BaseModel):
+    podcast: Optional[str]
+    feedID: Optional[int]
+    url: Optional[AnyUrl]
+    #
+    episode: Optional[str]
+    itemID: Optional[int]
+    episode_guid: Optional[str]
+    #
+    time: Optional[str]
+    ts: Optional[int]
+    action: Optional[str]
+    app_name: Optional[str]
+    app_version: Optional[str]
+    boost_link: Optional[str]
+    message: Optional[str]
+    name: Optional[str]
+    pubkey: Optional[str]
+    sender_key: Optional[str]
+    sender_name: Optional[str]
+    sender_id: Optional[str]
+    sig_fields: Optional[str]
+    signature: Optional[str]
+    speed: Optional[str]
+    uuid: Optional[str]
+    value_msat: Optional[int]
+    value_msat_total: Optional[int]
+
+
+
+class V4VItem(KeysendCustomRecord):
+    r_hash: str
+    add_index: int
+    value: int
+    settle_date: int
+    utc_datetime: datetime = None
+    localtime: datetime = None


### PR DESCRIPTION
This is just a code fragment which will help anyone who is trying to import a decoded 7629169 record in Python.

This might save someone else some typing, I can't open source right now the work I'm doing completely but it might be good to have a folder here of helpful code? There's probably a JS version of this that might be useful too.