### PR TITLE
add keys used by Thunder Hub

### DIFF
--- a/TLV_registry.md
+++ b/TLV_registry.md
@@ -12,11 +12,11 @@ Senders and apps can send custom TLV fields in Lightning payments. Open a [PR](h
 | 7629175       | podcast       | 64                    | PodcastIndex ID or GUID       |                               |
 | 34349334      | chat          | variable              | Chat message                  | Whatsat and more              |
 | 34349337      | chat          | ~71                   | Signature                     | See below                     |
+| 34349339      | chat          | 33                    | Chat message                  | Whatsat and more              |
 | 34349340      | chat          | variable              | Thunder Hub Sending Node Name |                               |
+| 34349343      | chat          | 8                     | Timestamp                     | See below                     |
 | 34349345      | chat          | variable              | Thunder Hub Content type      | typically "text"              |
 | 34349347      | chat          | variable              | Thunder Hub Request type      | typically "text"              |
-| 34349339      | chat          | 33                    | Chat message                  | Whatsat and more              |
-| 34349343      | chat          | 8                     | Timestamp                     | See below                     |
 | 133773310     | podcast       | variable              | JSON encoded data             | See below                     |
 | 5482373484    | keysend       | 32                    | Preimage as 32 bytes          |                               |
   

--- a/TLV_registry.md
+++ b/TLV_registry.md
@@ -12,6 +12,9 @@ Senders and apps can send custom TLV fields in Lightning payments. Open a [PR](h
 | 7629175       | podcast       | 64                    | PodcastIndex ID or GUID       |                               |
 | 34349334      | chat          | variable              | Chat message                  | Whatsat and more              |
 | 34349337      | chat          | ~71                   | Signature                     | See below                     |
+| 34349340      | chat          | variable              | Thunder Hub Sending Node Name |                               |
+| 34349345      | chat          | variable              | Thunder Hub Content type      | typically "text"              |
+| 34349347      | chat          | variable              | Thunder Hub Request type      | typically "text"              |
 | 34349339      | chat          | 33                    | Chat message                  | Whatsat and more              |
 | 34349343      | chat          | 8                     | Timestamp                     | See below                     |
 | 133773310     | podcast       | variable              | JSON encoded data             | See below                     |


### PR DESCRIPTION
Added three new custom records found in my logs:

34349340
34349345
34349347

Origin was identified as Thunder Hub's "chat" feature.