### PR TITLE
Fix typo

### DIFF
--- a/TLV_registry.md
+++ b/TLV_registry.md
@@ -42,7 +42,7 @@ Identifying the podcast **required**: use any of `podcast`, `feedID` or `url`. *
 * `guid` (str) [The `<podcast:guid>` tag](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#guid).
 
 Identifying the episode **recommended**: use any of `episode`, `itemID` or `episode_guid`. **itemID preferred**
-* `episode` (str) Episode of the podcas
+* `episode` (str) Episode of the podcast
 * `itemID` (int) ID of episode in PodcastIndex.org
 * `episode_guid` (str) The GUID of the episode
 


### PR DESCRIPTION
Fixes a typo: "podcas" -> "podcast"